### PR TITLE
fix: Resolve Vite build failures and logger issues

### DIFF
--- a/src/renderer/error/ErrorBoundary.tsx
+++ b/src/renderer/error/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { createLogger } from '../../shared/utils/logger';
+import { createLogger } from '../../shared/utils/logger.ts';
 import { RendererErrorHandler } from './RendererErrorHandler';
 
 const logger = createLogger('ErrorBoundary');

--- a/src/renderer/error/RendererErrorHandler.ts
+++ b/src/renderer/error/RendererErrorHandler.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '../../shared/utils/logger';
+import { createLogger } from '../../shared/utils/logger.ts';
 import type { ElectronAPI } from '../types/electron';
 // Define a shared ElectronAPI interface for type safety
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -4,7 +4,7 @@ import App from './App';
 import './index.css';
 
 // Import error handling
-import { createLogger } from '../shared/utils/logger';
+import { createLogger } from '../shared/utils/logger.ts';
 
 // Configure renderer logger
 const logger = createLogger('Renderer');

--- a/src/renderer/utils/LoggerProvider.tsx
+++ b/src/renderer/utils/LoggerProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, ReactNode } from 'react';
-import { Logger } from '../../shared/utils/logger';
+import { Logger } from '../../shared/utils/logger.ts';
 
 // Create the context
 interface LoggerContextType {

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,7 +1,18 @@
-import { app } from 'electron';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import { app as electronApp } from 'electron';
+
+// Environment detection
+const isNode = typeof window === 'undefined' && typeof process !== 'undefined' && process.versions && process.versions.node;
+
+let app: typeof electronApp | undefined;
+if (isNode) {
+  try {
+    // Dynamically require electron only in Node.js environment
+    app = require('electron').app;
+  } catch (e) {
+    console.warn("Running in Node.js environment but 'electron' module is not available. File logging features might be limited.");
+    app = undefined;
+  }
+}
 
 // Define log levels with numeric values for comparison
 export enum LogLevel {
@@ -34,32 +45,40 @@ const DEFAULT_CONFIG: LoggerConfig = {
 export class Logger {
   private static instance: Logger;
   private config: LoggerConfig;
-  private logDir: string;
-  private currentLogFile: string;
+  private logDir: string | null = null;
+  private currentLogFile: string | null = null;
   private currentLogSize: number = 0;
   
   private constructor(config: Partial<LoggerConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
-    
-    // Set up log directory
-    if (this.config.logDirectory) {
-      this.logDir = this.config.logDirectory;
+
+    if (isNode && this.config.logToFile) {
+      const node_os = require('os');
+      const node_path = require('path');
+      const node_fs = require('fs');
+
+      // Set up log directory
+      if (this.config.logDirectory) {
+        this.logDir = this.config.logDirectory;
+      } else {
+        const userDataPath = app?.getPath('userData') || node_path.join(node_os.homedir(), '.ai-character-council');
+        this.logDir = node_path.join(userDataPath, 'logs');
+      }
+      
+      // Ensure log directory exists
+      if (this.logDir && !node_fs.existsSync(this.logDir)) {
+        node_fs.mkdirSync(this.logDir, { recursive: true });
+      }
+      
+      this.currentLogFile = this.getLogFilePath(); // getLogFilePath will also use require for path
+      
+      // Check if file exists and get its size
+      if (this.currentLogFile && node_fs.existsSync(this.currentLogFile)) {
+        const stats = node_fs.statSync(this.currentLogFile);
+        this.currentLogSize = stats.size;
+      }
     } else {
-      const userDataPath = app?.getPath('userData') || path.join(os.homedir(), '.ai-character-council');
-      this.logDir = path.join(userDataPath, 'logs');
-    }
-    
-    // Ensure log directory exists
-    if (!fs.existsSync(this.logDir)) {
-      fs.mkdirSync(this.logDir, { recursive: true });
-    }
-    
-    this.currentLogFile = this.getLogFilePath();
-    
-    // Check if file exists and get its size
-    if (fs.existsSync(this.currentLogFile)) {
-      const stats = fs.statSync(this.currentLogFile);
-      this.currentLogSize = stats.size;
+      this.config.logToFile = false; // Disable file logging if not in Node.js or explicitly disabled
     }
     
     // Log startup information
@@ -68,6 +87,7 @@ export class Logger {
       config: this.config,
       timestamp: new Date().toISOString(),
       version: app?.getVersion() || 'unknown',
+      isNode,
     });
   }
   
@@ -154,8 +174,8 @@ export class Logger {
       this.logToConsole(level, formattedLog);
     }
     
-    // Log to file if enabled
-    if (this.config.logToFile) {
+    // Log to file if enabled and in Node.js environment
+    if (isNode && this.config.logToFile && this.currentLogFile) {
       this.logToFile(serializedEntry + '\n');
     }
   }
@@ -185,19 +205,26 @@ export class Logger {
    * Log to the current log file and handle rotation if needed
    */
   private logToFile(entry: string): void {
+    if (!isNode || !this.config.logToFile || !this.currentLogFile || !this.logDir) {
+      return; // Skip file logging if not in Node, disabled, or paths not set
+    }
     try {
+      const node_fs = require('fs');
       // Check if file needs rotation
       if (this.currentLogSize + entry.length > this.config.maxFileSize) {
-        this.rotateLogFiles();
+        this.rotateLogFiles(); // rotateLogFiles will use its own require for fs and path
       }
       
       // Append to log file
-      fs.appendFileSync(this.currentLogFile, entry);
-      this.currentLogSize += entry.length;
+      if (this.currentLogFile) { // Ensure currentLogFile is not null
+        node_fs.appendFileSync(this.currentLogFile, entry);
+        this.currentLogSize += entry.length;
+      }
     } catch (err) {
       // Fall back to console if file logging fails
       console.error('Failed to write to log file:', err);
       console.error('Log entry:', entry);
+      this.config.logToFile = false; // Disable further file logging attempts if an error occurs
     }
   }
   
@@ -205,39 +232,62 @@ export class Logger {
    * Rotate log files when current file exceeds max size
    */
   private rotateLogFiles(): void {
+    if (!isNode || !this.config.logToFile || !this.logDir) {
+      return;
+    }
     try {
-      const files = this.getExistingLogFiles();
+      const node_fs = require('fs');
+      const node_path = require('path');
+      const files = this.getExistingLogFiles(); // getExistingLogFiles will use its own require for fs
+      if (files === null) return; // Could not get existing files
       
       // Remove oldest file if we're at max files
       if (files.length >= this.config.maxFiles) {
         files.sort();
         const oldestFile = files[0];
-        fs.unlinkSync(path.join(this.logDir, oldestFile));
+        if (this.logDir) { // Ensure logDir is not null
+          node_fs.unlinkSync(node_path.join(this.logDir, oldestFile));
+        }
       }
       
       // Create new log file
-      this.currentLogFile = this.getLogFilePath();
+      this.currentLogFile = this.getLogFilePath(); // getLogFilePath will use its own require for path
       this.currentLogSize = 0;
     } catch (err) {
       console.error('Failed to rotate log files:', err);
+      this.config.logToFile = false; // Disable further file logging attempts
     }
   }
   
   /**
    * Get a list of existing log files
    */
-  private getExistingLogFiles(): string[] {
-    return fs.readdirSync(this.logDir)
-      .filter(file => file.startsWith('app-') && file.endsWith('.log'));
+  private getExistingLogFiles(): string[] | null {
+    if (!isNode || !this.logDir) {
+      return null;
+    }
+    try {
+      const node_fs = require('fs');
+      return node_fs.readdirSync(this.logDir)
+        .filter((file: string) => file.startsWith('app-') && file.endsWith('.log'));
+    } catch (err) {
+      console.error('Failed to read log directory:', err);
+      this.config.logToFile = false; // Disable file logging
+      return null;
+    }
   }
   
   /**
    * Generate the log file path for the current log
    */
-  private getLogFilePath(): string {
+  private getLogFilePath(): string | null {
+    if (!isNode || !this.logDir) {
+      return null;
+    }
+    const node_path = require('path');
     const date = new Date();
     const timestamp = date.toISOString().replace(/:/g, '-').replace(/\..+/, '');
-    return path.join(this.logDir, `app-${timestamp}.log`);
+    return node_path.join(this.logDir, `app-${timestamp}.log`);
   }
   
   /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
   },
   build: {
     outDir: 'build',
-    sourcemap: true
+    sourcemap: true,
+    rollupOptions: {
+      input: path.resolve(__dirname, 'public/index.html')
+    }
   }
 });


### PR DESCRIPTION
This commit addresses several issues that were causing the Vite build to fail:

1.  **Resolve "Could not resolve entry module index.html":** Modified `vite.config.ts` to explicitly set `build.rollupOptions.input` to `public/index.html`.

2.  **Fix Logger Module Export/Import Errors:** Corrected errors like "'createLogger' is not exported by src/shared/utils/logger.js" and "'Logger' is not exported by src/shared/utils/logger.js". This was achieved by changing import statements in the following files to explicitly point to `logger.ts` instead of relying on directory/extension resolution that picked up a `.js` file:
    - `src/renderer/error/RendererErrorHandler.ts`
    - `src/renderer/error/ErrorBoundary.tsx`
    - `src/renderer/utils/LoggerProvider.tsx`
    - `src/renderer/index.tsx`

3.  **Make Shared Logger Renderer-Friendly:** Refactored `src/shared/utils/logger.ts` to prevent Node.js built-in module warnings and errors when building for the renderer:
    - Node.js core modules (`fs`, `path`, `os`) and `electron.app` are now loaded dynamically using `require()` only within code paths that execute in a Node.js environment (`isNode === true`).
    - Static top-level imports for `fs`, `path`, and `os` were removed.
    - File system operations are now strictly conditional and will not run (or be bundled by Vite for the renderer) in the renderer context. The logger defaults to console-only output in the renderer if file logging is not available.

These changes collectively ensure that the Vite build process for the renderer completes successfully without errors or warnings related to module resolution or Node.js built-ins.